### PR TITLE
Use `html.parser` to avoid adding an extra doctype

### DIFF
--- a/mdformat_web/__init__.py
+++ b/mdformat_web/__init__.py
@@ -14,7 +14,8 @@ def format_css(unformatted: str, _info_str: str) -> str:
 
 
 def format_html(unformatted: str, _info_str: str) -> str:
-    soup = BeautifulSoup(unformatted, features="lxml")
+    # Use html.parser instead of lxml or html5lib to avoid adding an extra doctype.
+    soup = BeautifulSoup(unformatted, features="html.parser")
     return soup.prettify() + "\n"
 
 

--- a/tests/test_mdformat_web.py
+++ b/tests/test_mdformat_web.py
@@ -67,21 +67,17 @@ def test_html():
 ~~~
 """
     formatted_md = """```html
-<html>
- <body>
-  <ul>
-   <li>
-    foo
-   </li>
-  </ul>
-  <hr/>
-  <ul>
-   <li>
-    bar
-   </li>
-  </ul>
- </body>
-</html>
+<ul>
+ <li>
+  foo
+ </li>
+</ul>
+<hr/>
+<ul>
+ <li>
+  bar
+ </li>
+</ul>
 ```
 """
     assert mdformat.text(unformatted_md, codeformatters={"html"}) == formatted_md


### PR DESCRIPTION
This PR switch the base parser from `lxml` to `html.parser` for HTML prettifier. This will prevent code to be automatically wrapped with HTML doctype boilerplate.

In the current implementation, this Markdown syntax:
````md
```html
<div class="highlight">
    <pre>
       <span class="-Color -Color-C154 -C-C154"> __</span>
    </pre>
</div>
```
````

Is formatted to:
````md
```html
<html>
    <body>
        <div class="highlight">
            <pre>
                <span class="-Color -Color-C154 -C-C154"> __</span>
            </pre>
        </div>
    </body>
</html>
```
````

Notice how the snippet is being wrapped with `<html><body>`.

This PR will prevent this wrapping from happening.